### PR TITLE
Expose sqlite_utils to pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,3 +10,5 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install -U pytest
       - run: pytest -q
+        env:
+          PYTHONPATH: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- export PYTHONPATH during pytest so sqlite_utils.py is importable

## Testing
- not run (rely on CI)